### PR TITLE
feat: cpu optimization

### DIFF
--- a/src/client/haproxy.py
+++ b/src/client/haproxy.py
@@ -18,6 +18,7 @@ class HAProxy:
         self.optAllServersInFallback = Configuration().get("CLIENT_ALL_SERVERS_IN_FALLBACK_BACKEND")
         self.socketPath = Configuration().get("CLIENT_HAPROXY_SOCKET_PATH")
         self.backendName = Configuration().get("CLIENT_HAPROXY_BACKEND_NAME")
+        self.backendServerPort = str(Configuration().get("CLIENT_HAPROXY_BACKEND_SERVER_PORT"))
         self.fallbackBackendName = Configuration().get("CLIENT_HAPROXY_FALLBACK_BACKEND_NAME")
         self.backendBaseName = Configuration().get("CLIENT_HAPROXY_BACKEND_BASE_NAME")
         self.fallbackBackendBaseName = Configuration().get("CLIENT_HAPROXY_FALLBACK_BACKEND_BASE_NAME")
@@ -101,7 +102,7 @@ class HAProxy:
                     bckndName,
                     bckndbsName + str(server.backendServerID),
                     server.IPAddress,
-                    str(Configuration().get("CLIENT_HAPROXY_BACKEND_SERVER_PORT"),)
+                    self.backendServerPort
                 )
             )
             commands.append(


### PR DESCRIPTION
## Why
HSDO Client (next to HAProxy) is using 60% of CPU during heavy load in production. It's too much and it shouldn't rise that much (backend size list isn't moving after all, only enabled servers are moving)

## How
We found out after using [py-spy](https://github.com/benfred/py-spy) that for each enabled server, we reload all yaml configuration to fetch one parameter.
This is why cpu consumption rise during heavy load, as more and more servers are added. 
If we fetch needed parameter only once, HSDO Client cpu consumption shouldn't rise anymore.